### PR TITLE
Fix pretty print test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out
 .DS_Store
 .cabal-sandbox
 cabal.sandbox.config
+.stack-work

--- a/llvm-general-pure/test/LLVM/General/Test/PrettyPrint.hs
+++ b/llvm-general-pure/test/LLVM/General/Test/PrettyPrint.hs
@@ -78,13 +78,14 @@ tests = testGroup "PrettyPrint" [
             \            A.metadata' = []\n\
             \          }\n\
             \        )\n\
-            \      ]\n\
+            \      ],\n\
+            \      A.G.personalityFunction = Nothing\n\
             \    }\n\
             \  ]\n\
             \}"
     showPretty ast @?= s,
   testCase "imports" $ do
-    imports defaultPrefixScheme @?= 
+    imports defaultPrefixScheme @?=
       "import Data.Either\n\
       \import qualified Data.Map as Map\n\
       \import Data.Maybe\n\
@@ -109,4 +110,4 @@ tests = testGroup "PrettyPrint" [
       \import qualified LLVM.General.AST.Type as A\n\
       \import qualified LLVM.General.AST.Visibility as A.V\n"
  ]
-  
+


### PR DESCRIPTION
@cocreature just a quick fix for the pretty printer test.

The main `llvm-general` tests fail with:

```
    Assertion failed: (Val && "isa<> used on a null pointer"), function doit, file /private/tmp/llvm3820160316-8183-11u7j5k/llvm-3.8.0.src/include/llvm/Support/Casting.h, line 95.
```

Which in typical LLVM fashion is the most cryptic and useless error.
