### PR TITLE
Add withModuleFromASTForTargetMachine

### DIFF
--- a/llvm-general/src/LLVM/General/Module.hs
+++ b/llvm-general/src/LLVM/General/Module.hs
@@ -5,6 +5,7 @@ module LLVM.General.Module (
     File(..),
 
     withModuleFromAST,
+    withModuleFromASTForTargetMachine,
     moduleAST,
 
     withModuleFromLLVMAssembly,


### PR DESCRIPTION
This sets the AST.Module's DataLayout field to match that of the
TargetMachine. This is critical for getting name mangling right in
generated native code.
